### PR TITLE
Project navigation added

### DIFF
--- a/components/ProjectNav.js
+++ b/components/ProjectNav.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import ActiveLink from './ActiveLink'
+
+const ProjectNav = ({ projects }) => {
+  return (
+    <nav>
+      <ul className="u-flex f-row f-wrap">
+        {projects.map((project, index) => {
+          return (
+            <li key={index} className="mr-4">
+              <ActiveLink
+                as={`/projects/${project.slug}`}
+                href="/projects/[pathname]">
+                <a
+                  className={`u-fontSize20 u-fontWeightBold u-textColorDarkerHover u-transition-all300Custom`}>
+                  {project.title}
+                </a>
+              </ActiveLink>
+            </li>
+          )
+        })}
+      </ul>
+    </nav>
+  )
+}
+
+export default ProjectNav

--- a/pages/projects/[slug].js
+++ b/pages/projects/[slug].js
@@ -6,8 +6,9 @@ import ProjectTitle from '../../components/ProjectTitle'
 import ProjectSubTitle from '../../components/ProjectSubTitle'
 import ProjectParagraph from '../../components/ProjectParagraph'
 import ProjectBody from '../../components/ProjectBody'
+import ProjectNav from '../../components/ProjectNav'
 
-export default function Post({ project }) {
+export default function Post({ project, projects }) {
   const {
     title,
     subTitle,
@@ -59,6 +60,7 @@ export default function Post({ project }) {
         </div>
       </div>
       <ProjectBody description={description} website={website} code={code} />
+      <ProjectNav projects={projects} />
     </Layout>
   )
 }
@@ -77,11 +79,14 @@ export async function getStaticProps({ params }) {
     'type',
   ])
 
+  const allProjects = getAllProjects(['title', 'slug'])
+
   return {
     props: {
       project: {
         ...project,
       },
+      projects: [...allProjects],
     },
   }
 }


### PR DESCRIPTION
### PR

#### DESCRIPTION

Added a navigation on the bottom of individual page so user can navigation to other projects from the navigation instead of going back to home page and then selecting a project.

#### SCREENSHOT(S)
##### Without Navigation
<img width="1280" alt="without-nav" src="https://user-images.githubusercontent.com/19193724/80215049-7288ca00-8659-11ea-93e7-89f2c0ea7f97.png">

##### WIth Navigation
<img width="1280" alt="with-nav" src="https://user-images.githubusercontent.com/19193724/80214890-381f2d00-8659-11ea-947d-00df3cb92c69.png">

#### HOW TO TEST

- Run the app using **npm run dev**
- Open localhost:3000
- Select any project from the home screen
- Scroll to bottom on the individual project screen
- There should be a navigation for navigating to the other projects