### PR TITLE
ThemeSwitch added for dark/light theme

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import Link from 'next/link'
 import ActiveLink from './ActiveLink'
 import Hamburger from './Hamburger'
+import ThemeSwitch from './ThemSwitch'
 
 const navigation = [
   {
@@ -57,6 +58,9 @@ const Header = () => {
               </ActiveLink>
             </li>
           ))}
+          <li className="ml-5 phone-ml-3">
+            <ThemeSwitch />
+          </li>
         </ul>
         <div className="u-phoneShow">
           <Hamburger

--- a/components/ThemSwitch.js
+++ b/components/ThemSwitch.js
@@ -1,0 +1,105 @@
+import { useEffect } from 'react'
+
+const ThemeSwitch = () => {
+  let body = ''
+  useEffect(() => {
+    body = window.document.body
+  })
+
+  const handleThemeChange = e => {
+    const isChecked = event.target.checked
+    if (isChecked) {
+      body.classList.remove('light')
+      body.classList.add('dark')
+    } else {
+      body.classList.remove('dark')
+      body.classList.add('light')
+    }
+  }
+
+  return (
+    <div className="switch">
+      <input
+        className="switch__input"
+        type="checkbox"
+        id="switch"
+        onChange={handleThemeChange}
+      />
+      <label
+        aria-hidden="true"
+        className="switch__label"
+        htmlFor="switch"></label>
+      <div aria-hidden="true" className="switch__marker"></div>
+      <style jsx>
+        {`
+          --switch-width: 44px;
+          --switch-height: 22px;
+          --switch-padding: 2px;
+          --switch-animation-duration: 0.2s;
+
+          .switch {
+            display: flex;
+            flex-shrink: 0;
+            align-items: center;
+            position: relative;
+            width: var(--switch-width);
+            height: var(--switch-height);
+            border-radius: 50em;
+            padding: var(--switch-padding) 0;
+          }
+
+          .switch__input,
+          .switch__label {
+            position: absolute;
+            left: 0;
+            top: 0;
+          }
+
+          .switch__input {
+            margin: 0;
+            padding: 0;
+            opacity: 0;
+            height: 0;
+            width: 0;
+            pointer-events: none;
+          }
+
+          .switch__input:checked + .switch__label {
+            background-color: var(--color-black);
+          }
+
+          .switch__input:checked + .switch__label + .switch__marker {
+            left: calc(100% - var(--switch-height) + var(--switch-padding));
+          }
+
+          .switch__label {
+            width: 100%;
+            height: 100%;
+            color: transparent;
+            user-select: none;
+            background-color: var(--color-black);
+            border-radius: inherit;
+            z-index: 1;
+            transition: background var(--switch-animation-duration);
+          }
+
+          .switch__marker {
+            position: relative;
+            background-color: var(--color-white);
+            width: calc(var(--switch-height) - var(--switch-padding) * 2);
+            height: calc(var(--switch-height) - var(--switch-padding) * 2);
+            border-radius: 50%;
+            z-index: 2;
+            pointer-events: none;
+            box-shadow: 0 1px 1px rgba(0, 0, 0, 0.5);
+            left: var(--switch-padding);
+            transition: left var(--switch-animation-duration);
+            will-change: left;
+          }
+        `}
+      </style>
+    </div>
+  )
+}
+
+export default ThemeSwitch


### PR DESCRIPTION
### PR

#### DESCRIPTION

- Added light and dark mode to website.
- Added a theme switcher inside header for switching between light and dark mode.

#### SCREENSHOT(S)
##### Without Theme Switcher
<img width="1280" alt="without-mode" src="https://user-images.githubusercontent.com/19193724/80305989-06839e80-87de-11ea-8e03-0f62dd7e5c13.png">

##### With Theme Switcher
###### Light
<img width="1280" alt="with-mode-light" src="https://user-images.githubusercontent.com/19193724/80305999-0f747000-87de-11ea-8afb-aa5f6bd7eb8f.png">

###### Dark
<img width="1280" alt="with-mode-dark" src="https://user-images.githubusercontent.com/19193724/80306001-13a08d80-87de-11ea-812d-80da813b2244.png">

#### HOW TO TEST

- Run the app using **npm run dev**
- Open localhost:3000
- Switch the theme from header, it should toggle between light and dark