### PR TITLE
Sticky behaviour added to header

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -25,11 +25,8 @@ const navigation = [
 const Header = () => {
   const [isMenuCollapsed, setIsMenuCollapsed] = useState(true)
 
-  const mobileLinkClass =
-    'u-fontSize28 u-textColorNormal u-textColorDarkerHover u-width100Percent u-transition--transform300Spring'
-
   return (
-    <header className="u-flex align-items-center u-width100Percent u-height80 u-top0 u-left0 u-backgroundColor u-zIndex9">
+    <header className="u-flex align-items-center u-width100Percent u-height80 u-top0 u-left0 u-backgroundColor u-zIndex9 sticky">
       <nav className="u-flex justify-content-between align-items-center u-width100Percent u-height100Percent mx-auto u-maxWidth980 tabLand-pl-6 tabLand-pr-6 phone-pl-3 phone-pr-3 u-relative u-zIndex5">
         <Link href="/">
           <a
@@ -70,7 +67,9 @@ const Header = () => {
                     activeClassName="u-textColorDarkest"
                     href={item.link}
                     replace>
-                    <a className={mobileLinkClass}>{item.name}</a>
+                    <a className="u-fontSize28 u-textColorNormal u-textColorDarkerHover u-width100Percent u-transition--transform300Spring">
+                      {item.name}
+                    </a>
                   </ActiveLink>
                 </li>
               ))}
@@ -79,6 +78,11 @@ const Header = () => {
         </div>
       ) : null}
       <style jsx>{`
+        header.sticky {
+          position: sticky;
+          top: 0;
+        }
+
         .link {
           transition: all 250ms;
           padding: 0.6rem 1rem;


### PR DESCRIPTION
### PR

#### DESCRIPTION

Added sticky behaviour to the header.

#### SCREENSHOT(S)
##### Without sticky behaviour
<img width="400" alt="without-sticky-header" src="https://user-images.githubusercontent.com/19193724/81491154-4a7ba680-92a8-11ea-84cf-f6a3022c5a05.png">


##### With sticky behaviour
<img width="400" alt="with-sticky-header" src="https://user-images.githubusercontent.com/19193724/81491157-4e0f2d80-92a8-11ea-92c3-035ecd3dfc0f.png">


#### HOW TO TEST

- Run the app using **npm run dev**
- Open localhost:3000
- Header should stick to the top while scrolling